### PR TITLE
Fix guideline section

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -83,14 +83,14 @@ const modified = danger.git.modified_files;
 
   if (willShowGuidelines) {
     const message = `❤️ Good work!
-    
-    📚 If you are in wondering why these messages appear, [check out our PR guidelines](https://www.notion.so/pleo/PR-and-Code-Review-Culture-at-Pleo-220324344eb849f3b636cd00a28b4a41)!
-    
-    ---
-    
-    📄 _Guidelines are defined in [our Dangerfile](https://github.com/pleo-io/danger-config/blob/master/dangerfile.ts). Reach out to [#engprod-devexp](https://getpleo.slack.com/archives/C030H8BMU8K) on Slack for questions._
-    
-    `;
+
+📚 If you are in wondering why these messages appear, [check out our PR guidelines](https://www.notion.so/pleo/PR-and-Code-Review-Culture-at-Pleo-220324344eb849f3b636cd00a28b4a41)!
+
+---
+
+📄 _Guidelines are defined in [our Dangerfile](https://github.com/pleo-io/danger-config/blob/master/dangerfile.ts). Reach out to [#engprod-devexp](https://getpleo.slack.com/archives/C030H8BMU8K) on Slack for questions._
+
+`;
     markdown(message);
   }
 })();


### PR DESCRIPTION
TL;DR: Markdown + Indentation = Code-Block. What? Yeah: https://github.com/pleo-io/pluto/pull/418#issuecomment-1164580293

These two paragraphs show up formatted as a code block and I didn't understand at all, why - because there was no obvious code block visible in the configuration. Until it hit me:

> To produce a code block in Markdown, simply indent every line of the block by at least 4 spaces or 1 tab. ([ref](https://daringfireball.net/projects/markdown/syntax#precode)) 