### PR TITLE
Improve the code creation/modification test rule

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -50,14 +50,14 @@ const created = danger.git.created_files;
   const hasCreatedKotlin = created.some((path) => path.endsWith(".kt"));
   const hasCreatedTests = created.some((f) => f.match(/test/));
 
-  if (hasCreatedKotlin && !hasCreatedTests) {
-    const comment = `This PR does not add tests for newly created files`;
+  const hasModifiedKotlin = modified.some((path) => path.endsWith(".kt"));
+  const hasModifiedTests = modified.some((f) => f.match(/test/));
+
+  if (hasCreatedKotlin && (!hasCreatedTests || !hasModifiedTests)) {
+    const comment = `This PR does not add or modify tests for newly created files`;
     warn(comment);
     willShowGuidelines = true;
   }
-
-  const hasModifiedKotlin = modified.some((path) => path.endsWith(".kt"));
-  const hasModifiedTests = modified.some((f) => f.match(/test/));
 
   if (hasModifiedKotlin && !hasModifiedTests) {
     const comment = `This PR does not modify tests for changed files`;


### PR DESCRIPTION
Linear ticket: [DX-425](https://linear.app/pleo/issue/DX-425)

## Description

This PR aims for fixing the DangerJS GitHub message in case new kotlin files were created and at the same time existing tests were modified.